### PR TITLE
Include <iostream>, needed for declaration of std::istream

### DIFF
--- a/Code/encoding/src/Structs/AnimationVariables.cpp
+++ b/Code/encoding/src/Structs/AnimationVariables.cpp
@@ -1,5 +1,6 @@
 #include <Structs/AnimationVariables.h>
 #include <Serialization.hpp>
+#include <iostream>
 
 bool AnimationVariables::operator==(const AnimationVariables& acRhs) const noexcept
 {


### PR DESCRIPTION
This was necessary to compile on VS2019