### PR TITLE
Change suggested version of visual studio to 16.8

### DIFF
--- a/.ci/windows-build.yml
+++ b/.ci/windows-build.yml
@@ -20,7 +20,6 @@ steps:
         msbuildArgs: -m
         Configuration: $(configuration)
         Platform: $(platform)
-        vsVersion: 16.0
       env:
         DXSDK_DIR: $(Build.SourcesDirectory)\DXSDK
   

--- a/.ci/windows-build.yml
+++ b/.ci/windows-build.yml
@@ -20,7 +20,7 @@ steps:
         msbuildArgs: -m
         Configuration: $(configuration)
         Platform: $(platform)
-        vsVersion: 16.8
+        vsVersion: 16.0
       env:
         DXSDK_DIR: $(Build.SourcesDirectory)\DXSDK
   

--- a/.ci/windows-build.yml
+++ b/.ci/windows-build.yml
@@ -20,6 +20,7 @@ steps:
         msbuildArgs: -m
         Configuration: $(configuration)
         Platform: $(platform)
+        vsVersion: 16.8
       env:
         DXSDK_DIR: $(Build.SourcesDirectory)\DXSDK
   

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This framework was created to enable multiplayer in Bethesda games, at the momen
 
 ### Windows
 
-You will need [Visual Studio 2019](https://www.visualstudio.com/downloads/) (the community edition is freely available for download) and [Directx SDK](https://www.microsoft.com/en-us/download/details.aspx?id=6812) to build the project, aswell [Node.js](https://nodejs.org/en/) for the scripts to run properly.
+You will need [Visual Studio 2019 Version 16.8 Preview 2](https://devblogs.microsoft.com/visualstudio/visual-studio-2019-v16-8-preview-2/) (the community edition is freely available for download) and [Directx SDK](https://www.microsoft.com/en-us/download/details.aspx?id=6812) to build the project, aswell [Node.js](https://nodejs.org/en/) for the scripts to run properly.
 
 Check GETTINGSTARTED.md for the detailed steps.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This framework was created to enable multiplayer in Bethesda games, at the momen
 
 ### Windows
 
-You will need [Visual Studio 2019 Version 16.8 Preview 2](https://devblogs.microsoft.com/visualstudio/visual-studio-2019-v16-8-preview-2/) (the community edition is freely available for download) and [Directx SDK](https://www.microsoft.com/en-us/download/details.aspx?id=6812) to build the project, aswell [Node.js](https://nodejs.org/en/) for the scripts to run properly.
+You will need [Visual Studio 2019 Version 16.8 Preview 2](https://devblogs.microsoft.com/visualstudio/visual-studio-2019-v16-8-preview-2/) (the community edition is freely available). **Early versions of Visual Studio will not work**. You will also need [Directx SDK](https://www.microsoft.com/en-us/download/details.aspx?id=6812) to build the project, aswell [Node.js](https://nodejs.org/en/) for the scripts to run properly.
 
 Check GETTINGSTARTED.md for the detailed steps.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This framework was created to enable multiplayer in Bethesda games, at the momen
 
 ### Windows
 
-You will need [Visual Studio 2019 Version 16.8 Preview 2](https://devblogs.microsoft.com/visualstudio/visual-studio-2019-v16-8-preview-2/) (the community edition is freely available). **Early versions of Visual Studio will not work**. You will also need [Directx SDK](https://www.microsoft.com/en-us/download/details.aspx?id=6812) to build the project, aswell [Node.js](https://nodejs.org/en/) for the scripts to run properly.
+You will need [Visual Studio 2019 Version 16.8 Preview 2](https://devblogs.microsoft.com/visualstudio/visual-studio-2019-v16-8-preview-2/) (the community edition is freely available). **Earlier versions of Visual Studio will not work**. You will also need [Directx SDK](https://www.microsoft.com/en-us/download/details.aspx?id=6812) to build the project, aswell [Node.js](https://nodejs.org/en/) for the scripts to run properly.
 
 Check GETTINGSTARTED.md for the detailed steps.
 


### PR DESCRIPTION
This PR is a follow up to #60 and is a fix for #61

I tried to use sol.hpp from the 3.2.1 release but encountered the same compilation issues. So I'm putting this pr back up.

I tried changing the window_build to use 16.8 since azure pipelines were previously crashing due to the same issue. But the vsBuild and msBuild tasks do not support this version. 