### PR TITLE
Actor value sync

### DIFF
--- a/Code/client/include/Events/HitEvent.h
+++ b/Code/client/include/Events/HitEvent.h
@@ -1,0 +1,14 @@
+#pragma once
+
+struct TESObjectREFR;
+
+struct HitEvent
+{
+    HitEvent(TESObjectREFR* aHit, TESObjectREFR* aHitter) 
+        : Hit(aHit)
+        , Hitter(aHitter)
+    {}
+
+    TESObjectREFR* Hit;
+    TESObjectREFR* Hitter;
+};

--- a/Code/client/include/Games/Skyrim/Events/EventDispatcher.h
+++ b/Code/client/include/Games/Skyrim/Events/EventDispatcher.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <TESObjectREFR.h>
+
 template <class T> struct BSTEventSink;
 
 // Very nasty work around to avoid template code duplication
@@ -118,7 +120,8 @@ struct TESGrabReleaseEvent
 
 struct TESHitEvent
 {
-
+    TESObjectREFR* hit;
+    TESObjectREFR* hitter;
 };
 
 struct TESLoadGameEvent

--- a/Code/client/include/Services/ActorService.h
+++ b/Code/client/include/Services/ActorService.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <Events/EventDispatcher.h>
+#include <Games/Events.h>
+
+struct World;
+struct UpdateEvent;
+struct TransportService;
+struct NotifyActorValueChanges;
+
+struct ActorService : BSTEventSink<TESHitEvent>
+{
+  public:
+    ActorService(entt::dispatcher& aDispatcher, World& aWorld, TransportService& aTransport) noexcept;
+    ~ActorService() noexcept;
+
+    TP_NOCOPYMOVE(ActorService);
+
+private:
+
+    World& m_world;
+    TransportService& m_transport;
+    
+    void UpdateHealth(const UpdateEvent&) noexcept;
+    void OnActorValueChanges(const NotifyActorValueChanges& acMessage) const noexcept;
+    BSTEventResult OnEvent(const TESHitEvent*, const EventDispatcher<TESHitEvent>*) override;
+
+    entt::scoped_connection m_updateHealthConnection;
+};

--- a/Code/client/include/Services/ActorService.h
+++ b/Code/client/include/Services/ActorService.h
@@ -10,6 +10,7 @@ struct DisconnectedEvent;
 struct ReferenceSpawnedEvent;
 struct ReferenceRemovedEvent;
 struct UpdateEvent;
+struct HitEvent;
 
 struct TransportService;
 struct NotifyActorValueChanges;
@@ -38,6 +39,8 @@ private:
     void OnReferenceRemoved(const ReferenceRemovedEvent&) noexcept;
     void OnUpdate(const UpdateEvent&) noexcept;
     void OnActorValueChanges(const NotifyActorValueChanges& acMessage) noexcept;
+    void OnHit(const HitEvent&) noexcept;
+
     BSTEventResult OnEvent(const TESHitEvent*, const EventDispatcher<TESHitEvent>*) override;
 
     void AddToActorMap(uint32_t aId, Actor* aActor) noexcept;

--- a/Code/client/include/Services/ActorService.h
+++ b/Code/client/include/Services/ActorService.h
@@ -37,10 +37,9 @@ private:
     void OnReferenceSpawned(const ReferenceSpawnedEvent&) noexcept;
     void OnReferenceRemoved(const ReferenceRemovedEvent&) noexcept;
     void OnUpdate(const UpdateEvent&) noexcept;
-    void OnActorValueChanges(const NotifyActorValueChanges& acMessage) const noexcept;
+    void OnActorValueChanges(const NotifyActorValueChanges& acMessage) noexcept;
     BSTEventResult OnEvent(const TESHitEvent*, const EventDispatcher<TESHitEvent>*) override;
 
     void AddToActorMap(uint32_t aId, Actor* aActor) noexcept;
-
-    entt::scoped_connection m_updateConnection;
+    void ForceActorValue(Actor* aActor, uint32_t aId, float aValue) noexcept;
 };

--- a/Code/client/include/Services/ActorService.h
+++ b/Code/client/include/Services/ActorService.h
@@ -4,9 +4,17 @@
 #include <Games/Events.h>
 
 struct World;
+
+struct ConnectedEvent;
+struct DisconnectedEvent;
+struct ReferenceSpawnedEvent;
+struct ReferenceRemovedEvent;
 struct UpdateEvent;
+
 struct TransportService;
 struct NotifyActorValueChanges;
+
+struct Actor;
 
 struct ActorService : BSTEventSink<TESHitEvent>
 {
@@ -20,10 +28,19 @@ private:
 
     World& m_world;
     TransportService& m_transport;
+
+    Map<uint32_t, Map<uint32_t, float>> m_actorValues;
+    double m_timeSinceDiff = 1;
     
-    void UpdateHealth(const UpdateEvent&) noexcept;
+    void OnLocalComponentAdded(entt::registry& aRegistry, entt::entity aEntity) noexcept;
+    void OnDisconnected(const DisconnectedEvent&) noexcept;
+    void OnReferenceSpawned(const ReferenceSpawnedEvent&) noexcept;
+    void OnReferenceRemoved(const ReferenceRemovedEvent&) noexcept;
+    void OnUpdate(const UpdateEvent&) noexcept;
     void OnActorValueChanges(const NotifyActorValueChanges& acMessage) const noexcept;
     BSTEventResult OnEvent(const TESHitEvent*, const EventDispatcher<TESHitEvent>*) override;
 
-    entt::scoped_connection m_updateHealthConnection;
+    void AddToActorMap(uint32_t aId, Actor* aActor) noexcept;
+
+    entt::scoped_connection m_updateConnection;
 };

--- a/Code/client/src/Services/Generic/ActorService.cpp
+++ b/Code/client/src/Services/Generic/ActorService.cpp
@@ -1,0 +1,56 @@
+#include <Services/ActorService.h>
+#include <World.h>
+#include <Forms/ActorValueInfo.h>
+#include <Games/References.h>
+#include <Components.h>
+#include <Events/UpdateEvent.h>
+#include <Messages/NotifyActorValueChanges.h>
+#include <Messages/RequestActorValueChanges.h>
+
+ActorService::ActorService(entt::dispatcher& aDispatcher, World& aWorld, TransportService& aTransport) noexcept
+    : m_world(aWorld)
+    , m_transport(aTransport)
+{
+    aDispatcher.sink<NotifyActorValueChanges>().connect<&ActorService::OnActorValueChanges>(this);
+    EventDispatcherManager::Get()->hitEvent.RegisterSink(this);
+}
+
+ActorService::~ActorService() noexcept
+{
+}
+
+BSTEventResult ActorService::OnEvent(const TESHitEvent* hitEvent, const EventDispatcher<TESHitEvent>* dispatcher)
+{
+    std::cout << "Damaged!" << std::endl;
+
+    auto view = m_world.view<FormIdComponent, LocalComponent>();
+    for (auto entity : view)
+    {
+        auto& formIdComponent = view.get<FormIdComponent>(entity);
+        auto* pForm = TESForm::GetById(formIdComponent.Id);
+        auto* pActor = RTTI_CAST(pForm, TESForm, Actor);
+
+        if (pActor != NULL)
+        {
+            RequestActorValueChanges requestChanges;
+            requestChanges.m_formId = formIdComponent.Id;
+            requestChanges.m_health = pActor->actorValueOwner.GetValue(ActorValueInfo::kHealth);
+            m_transport.Send(requestChanges);
+        }
+    }
+
+    return BSTEventResult::kAbort;
+}
+
+void ActorService::OnActorValueChanges(const NotifyActorValueChanges& acEvent) const noexcept
+{
+    auto* pForm = TESForm::GetById(acEvent.m_formId);
+    auto* pActor = RTTI_CAST(pForm, TESForm, Actor);
+
+    #if TP_SKYRIM
+    if (pActor != NULL)
+    {
+        pActor->actorValueOwner.SetValue(24, acEvent.m_health);
+    }
+    #endif
+}

--- a/Code/client/src/Services/Generic/ActorService.cpp
+++ b/Code/client/src/Services/Generic/ActorService.cpp
@@ -21,25 +21,18 @@ ActorService::~ActorService() noexcept
 
 BSTEventResult ActorService::OnEvent(const TESHitEvent* hitEvent, const EventDispatcher<TESHitEvent>* dispatcher)
 {
-    std::cout << "Damaged!" << std::endl;
+    auto* pActor = RTTI_CAST(hitEvent->hit, TESObjectREFR, Actor);
 
-    auto view = m_world.view<FormIdComponent, LocalComponent>();
-    for (auto entity : view)
+    if (pActor != NULL)
     {
-        auto& formIdComponent = view.get<FormIdComponent>(entity);
-        auto* pForm = TESForm::GetById(formIdComponent.Id);
-        auto* pActor = RTTI_CAST(pForm, TESForm, Actor);
-
-        if (pActor != NULL)
-        {
-            RequestActorValueChanges requestChanges;
-            requestChanges.m_formId = formIdComponent.Id;
-            requestChanges.m_health = pActor->actorValueOwner.GetValue(ActorValueInfo::kHealth);
-            m_transport.Send(requestChanges);
-        }
+        RequestActorValueChanges requestChanges;
+        requestChanges.m_formId = hitEvent->hit->formID;
+        std::cout << "Actor " << hitEvent->hit->formID << " has " << pActor->actorValueOwner.GetValue(ActorValueInfo::kHealth) << " health" << std::endl;
+        requestChanges.m_health = pActor->actorValueOwner.GetValue(ActorValueInfo::kHealth);
+        m_transport.Send(requestChanges);
     }
 
-    return BSTEventResult::kAbort;
+    return BSTEventResult::kOk;
 }
 
 void ActorService::OnActorValueChanges(const NotifyActorValueChanges& acEvent) const noexcept

--- a/Code/client/src/Services/Generic/ActorService.cpp
+++ b/Code/client/src/Services/Generic/ActorService.cpp
@@ -162,7 +162,7 @@ BSTEventResult ActorService::OnEvent(const TESHitEvent* hitEvent, const EventDis
     return BSTEventResult::kOk;
 }
 
-void ActorService::OnActorValueChanges(const NotifyActorValueChanges& acEvent) const noexcept
+void ActorService::OnActorValueChanges(const NotifyActorValueChanges& acEvent) noexcept
 {
     auto view = m_world.view<FormIdComponent, RemoteComponent>();
 
@@ -181,9 +181,27 @@ void ActorService::OnActorValueChanges(const NotifyActorValueChanges& acEvent) c
                 {
                     std::cout << "Form ID: " << std::hex << formIdComponent.Id << " Remote ID: " << std::hex << acEvent.m_Id << std::endl;
                     std::cout << "Key: " << std::dec << value.first << " Value: " << value.second << std::endl;
-                    pActor->actorValueOwner.SetValue(value.first, value.second);
+
+                    if (value.first == ActorValueInfo::kHealth || value.first == ActorValueInfo::kStamina || value.first == ActorValueInfo::kMagicka)
+                    {
+                        ForceActorValue(pActor, value.first, value.second);
+                    }
+                    else
+                    {
+                        pActor->actorValueOwner.SetValue(value.first, value.second);
+                    }                    
                 }
             }
         }
     }
+}
+
+void ActorService::ForceActorValue(Actor* aActor, uint32_t aId, float aValue) noexcept
+{
+    float current = aActor->actorValueOwner.GetValue(aId);
+    float max = aActor->actorValueOwner.GetMaxValue(aId);
+
+    aActor->actorValueOwner.ForceCurrent(2, aId, max - current);
+
+    aActor->actorValueOwner.ForceCurrent(2, aId, aValue - max);
 }

--- a/Code/client/src/Services/Generic/ActorService.cpp
+++ b/Code/client/src/Services/Generic/ActorService.cpp
@@ -3,7 +3,13 @@
 #include <Forms/ActorValueInfo.h>
 #include <Games/References.h>
 #include <Components.h>
+
 #include <Events/UpdateEvent.h>
+#include <Events/ReferenceSpawnedEvent.h>
+#include <Events/ReferenceRemovedEvent.h>
+#include <Events/ConnectedEvent.h>
+#include <Events/DisconnectedEvent.h>
+
 #include <Messages/NotifyActorValueChanges.h>
 #include <Messages/RequestActorValueChanges.h>
 
@@ -11,6 +17,11 @@ ActorService::ActorService(entt::dispatcher& aDispatcher, World& aWorld, Transpo
     : m_world(aWorld)
     , m_transport(aTransport)
 {
+    m_world.on_construct<LocalComponent>().connect<&ActorService::OnLocalComponentAdded>(this);
+    aDispatcher.sink<DisconnectedEvent>().connect<&ActorService::OnDisconnected>(this);
+    aDispatcher.sink<ReferenceSpawnedEvent>().connect<&ActorService::OnReferenceSpawned>(this);
+    aDispatcher.sink<ReferenceRemovedEvent>().connect<&ActorService::OnReferenceRemoved>(this);
+    aDispatcher.sink<UpdateEvent>().connect<&ActorService::OnUpdate>(this);
     aDispatcher.sink<NotifyActorValueChanges>().connect<&ActorService::OnActorValueChanges>(this);
     EventDispatcherManager::Get()->hitEvent.RegisterSink(this);
 }
@@ -19,17 +30,133 @@ ActorService::~ActorService() noexcept
 {
 }
 
+void ActorService::AddToActorMap(uint32_t aId, Actor* aActor) noexcept
+{
+    Map<uint32_t, float> values;
+    for (int i = 0; i < 164; i++)
+    {
+        float value = aActor->actorValueOwner.GetValue(i);
+        values.insert({i, value});
+    }
+    m_actorValues.insert({aId, values});
+}
+
+void ActorService::OnLocalComponentAdded(entt::registry& aRegistry, const entt::entity aEntity) noexcept
+{
+    auto& formIdComponent = aRegistry.get<FormIdComponent>(aEntity);
+    auto& localComponent = aRegistry.get<LocalComponent>(aEntity);
+    auto* pForm = TESForm::GetById(formIdComponent.Id);
+    auto* pActor = RTTI_CAST(pForm, TESForm, Actor);
+
+    if (pActor != NULL)
+    {
+        //std::cout << "Form: " << std::hex << formIdComponent.Id << " Local: " << std::hex << localComponent.Id << std::endl;
+        AddToActorMap(localComponent.Id, pActor);
+    }
+}
+
+void ActorService::OnDisconnected(const DisconnectedEvent& acEvent) noexcept
+{
+    m_actorValues.clear();
+}
+
+void ActorService::OnReferenceSpawned(const ReferenceSpawnedEvent& acEvent) noexcept
+{
+    if (m_transport.IsConnected())
+    {
+        auto* localComponent = m_world.try_get<LocalComponent>(acEvent.Entity);
+        if (localComponent != NULL)
+        {
+            auto* pForm = TESForm::GetById(acEvent.FormId);
+            auto* pActor = RTTI_CAST(pForm, TESForm, Actor);
+
+            if (pActor != NULL)
+            {
+                AddToActorMap(localComponent->Id, pActor);
+            }
+        }
+    }    
+}
+
+void ActorService::OnReferenceRemoved(const ReferenceRemovedEvent& acEvent) noexcept
+{
+    if (m_transport.IsConnected())
+    {
+        m_actorValues.erase(acEvent.FormId);
+    }    
+}
+
+void ActorService::OnUpdate(const UpdateEvent& acEvent) noexcept
+{
+    m_timeSinceDiff += acEvent.Delta;
+    if (m_timeSinceDiff >= 1)
+    {
+        m_timeSinceDiff = 0;
+
+        auto view = m_world.view<FormIdComponent, LocalComponent>();
+
+        for (auto& value : m_actorValues)
+        {
+            for (auto entity : view)
+            {
+                auto& localComponent = view.get<LocalComponent>(entity);
+                if (localComponent.Id == value.first)
+                {
+                    auto& formIdComponent = view.get<FormIdComponent>(entity);
+                    auto* pForm = TESForm::GetById(formIdComponent.Id);
+                    auto* pActor = RTTI_CAST(pForm, TESForm, Actor);
+
+                    if (pActor != NULL)
+                    {
+                        RequestActorValueChanges requestChanges;
+                        requestChanges.m_Id = value.first;
+
+                        for (int i = 0; i < 164; i++)
+                        {
+                            float oldValue = value.second[i];
+                            float newValue = pActor->actorValueOwner.GetValue(i);
+                            if (newValue != oldValue)
+                            {
+                                requestChanges.m_values.insert({i, newValue});
+                                value.second[i] = newValue;
+                            }
+                        }
+
+                        if (requestChanges.m_values.size() > 0)
+                        {
+                            m_transport.Send(requestChanges);
+                        }
+                    }
+                }
+            }
+        }        
+    }    
+}
+
 BSTEventResult ActorService::OnEvent(const TESHitEvent* hitEvent, const EventDispatcher<TESHitEvent>* dispatcher)
 {
     auto* pActor = RTTI_CAST(hitEvent->hit, TESObjectREFR, Actor);
 
     if (pActor != NULL)
     {
-        RequestActorValueChanges requestChanges;
-        requestChanges.m_formId = hitEvent->hit->formID;
-        std::cout << "Actor " << hitEvent->hit->formID << " has " << pActor->actorValueOwner.GetValue(ActorValueInfo::kHealth) << " health" << std::endl;
-        requestChanges.m_health = pActor->actorValueOwner.GetValue(ActorValueInfo::kHealth);
-        m_transport.Send(requestChanges);
+        float health = pActor->actorValueOwner.GetValue(ActorValueInfo::kHealth);
+
+        auto view = m_world.view<FormIdComponent, LocalComponent>();
+
+        for (auto entity : view)
+        {
+            auto& formIdComponent = view.get<FormIdComponent>(entity);
+            if (formIdComponent.Id == hitEvent->hit->formID)
+            {
+                auto& localComponent = view.get<LocalComponent>(entity);
+
+                RequestActorValueChanges requestChanges;
+                requestChanges.m_Id = localComponent.Id;
+                requestChanges.m_values.insert({ActorValueInfo::kHealth, health});
+
+                m_transport.Send(requestChanges);
+            }
+        }
     }
 
     return BSTEventResult::kOk;
@@ -37,13 +164,26 @@ BSTEventResult ActorService::OnEvent(const TESHitEvent* hitEvent, const EventDis
 
 void ActorService::OnActorValueChanges(const NotifyActorValueChanges& acEvent) const noexcept
 {
-    auto* pForm = TESForm::GetById(acEvent.m_formId);
-    auto* pActor = RTTI_CAST(pForm, TESForm, Actor);
+    auto view = m_world.view<FormIdComponent, RemoteComponent>();
 
-    #if TP_SKYRIM
-    if (pActor != NULL)
+    for (auto entity : view)
     {
-        pActor->actorValueOwner.SetValue(24, acEvent.m_health);
+        auto& remoteComponent = view.get<RemoteComponent>(entity);
+        if (remoteComponent.Id == acEvent.m_Id)
+        {
+            auto& formIdComponent = view.get<FormIdComponent>(entity);
+            auto* pForm = TESForm::GetById(formIdComponent.Id);
+            auto* pActor = RTTI_CAST(pForm, TESForm, Actor);
+
+            if (pActor != NULL)
+            {
+                for (auto& value : acEvent.m_values)
+                {
+                    std::cout << "Form ID: " << std::hex << formIdComponent.Id << " Remote ID: " << std::hex << acEvent.m_Id << std::endl;
+                    std::cout << "Key: " << std::dec << value.first << " Value: " << value.second << std::endl;
+                    pActor->actorValueOwner.SetValue(value.first, value.second);
+                }
+            }
+        }
     }
-    #endif
 }

--- a/Code/client/src/Services/Generic/EntityService.cpp
+++ b/Code/client/src/Services/Generic/EntityService.cpp
@@ -2,6 +2,7 @@
 
 #include <Events/ReferenceAddedEvent.h>
 #include <Events/ReferenceRemovedEvent.h>
+#include <Events/ReferenceSpawnedEvent.h>
 
 #include <World.h>
 
@@ -44,6 +45,8 @@ void EntityService::OnReferenceAdded(const ReferenceAddedEvent& acEvent) noexcep
         m_world.emplace<FormIdComponent>(entity, acEvent.FormId);
 
         m_refIdToEntity[acEvent.FormId] = entity;
+
+        m_dispatcher.trigger(ReferenceSpawnedEvent(acEvent.FormId, acEvent.FormType, entity));
     }
 }
 

--- a/Code/client/src/Services/Generic/TransportService.cpp
+++ b/Code/client/src/Services/Generic/TransportService.cpp
@@ -37,6 +37,7 @@
 #include <Messages/NotifyPartyInfo.h>
 #include <Messages/NotifyPartyInvite.h>
 #include <Messages/NotifyCharacterTravel.h>
+#include <Messages/NotifyActorValueChanges.h>
 
 #define TRANSPORT_DISPATCH(packetName) \
 case k##packetName: \
@@ -121,6 +122,7 @@ void TransportService::OnConsume(const void* apData, uint32_t aSize)
     TRANSPORT_DISPATCH(NotifyPartyInfo);
     TRANSPORT_DISPATCH(NotifyPartyInvite);
     TRANSPORT_DISPATCH(NotifyCharacterTravel);
+    TRANSPORT_DISPATCH(NotifyActorValueChanges);
 
     default:
         spdlog::error("Client message opcode {} from server has no handler", pMessage->GetOpcode());

--- a/Code/client/src/World.cpp
+++ b/Code/client/src/World.cpp
@@ -15,6 +15,7 @@
 #include <Services/EnvironmentService.h>
 #include <Services/QuestService.h>
 #include <Services/PartyService.h>
+#include <Services/ActorService.h>
 
 #include <Events/PreUpdateEvent.h>
 #include <Events/UpdateEvent.h>
@@ -37,6 +38,7 @@ World::World()
     set<EnvironmentService>(*this, m_dispatcher);
     set<QuestService>(*this, m_dispatcher, ctx<ImguiService>());
     set<PartyService>(m_dispatcher, ctx<ImguiService>(), m_transport);
+    set<ActorService>(m_dispatcher, *this, m_transport);
 }
 
 World::~World() = default;

--- a/Code/encoding/include/Messages/NotifyActorValueChanges.h
+++ b/Code/encoding/include/Messages/NotifyActorValueChanges.h
@@ -13,11 +13,10 @@ struct NotifyActorValueChanges final : ServerMessage
 
     bool operator==(const NotifyActorValueChanges& acRhs) const noexcept
     {
-        return m_formId == acRhs.m_formId && 
-            m_health == acRhs.m_health &&
-            GetOpcode() == acRhs.GetOpcode();
+        return m_Id == acRhs.m_Id && 
+               GetOpcode() == acRhs.GetOpcode();
     }
 
-    uint32_t m_formId;
-    uint32_t m_health;
+    uint32_t m_Id;
+    Map<uint32_t, float> m_values;
 };

--- a/Code/encoding/include/Messages/NotifyActorValueChanges.h
+++ b/Code/encoding/include/Messages/NotifyActorValueChanges.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Message.h"
+
+struct NotifyActorValueChanges final : ServerMessage
+{
+    NotifyActorValueChanges() : ServerMessage(kNotifyActorValueChanges)
+    {
+    }
+
+    void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
+    void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
+
+    bool operator==(const NotifyActorValueChanges& acRhs) const noexcept
+    {
+        return m_formId == acRhs.m_formId && 
+            m_health == acRhs.m_health &&
+            GetOpcode() == acRhs.GetOpcode();
+    }
+
+    uint32_t m_formId;
+    uint32_t m_health;
+};

--- a/Code/encoding/include/Messages/RequestActorValueChanges.h
+++ b/Code/encoding/include/Messages/RequestActorValueChanges.h
@@ -13,9 +13,10 @@ struct RequestActorValueChanges final : ClientMessage
 
     bool operator==(const RequestActorValueChanges& acRhs) const noexcept
     {
-        return m_formId == acRhs.m_formId && m_health == acRhs.m_health && GetOpcode() == acRhs.GetOpcode();
+        return m_Id == acRhs.m_Id && 
+               GetOpcode() == acRhs.GetOpcode();
     }
 
-    uint32_t m_formId;
-    uint32_t m_health;
+    uint32_t m_Id;
+    Map<uint32_t, float> m_values;
 };

--- a/Code/encoding/include/Messages/RequestActorValueChanges.h
+++ b/Code/encoding/include/Messages/RequestActorValueChanges.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Message.h"
+
+struct RequestActorValueChanges final : ClientMessage
+{
+    RequestActorValueChanges() : ClientMessage(kRequestActorValueChanges)
+    {
+    }
+
+    void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
+    void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
+
+    bool operator==(const RequestActorValueChanges& acRhs) const noexcept
+    {
+        return m_formId == acRhs.m_formId && m_health == acRhs.m_health && GetOpcode() == acRhs.GetOpcode();
+    }
+
+    uint32_t m_formId;
+    uint32_t m_health;
+};

--- a/Code/encoding/include/Opcodes.h
+++ b/Code/encoding/include/Opcodes.h
@@ -16,6 +16,7 @@ enum ClientOpcode : unsigned char
     kPartyAcceptInviteRequest,
     kPartyLeaveRequest,
     kCharacterTravelRequest,
+    kRequestActorValueChanges
 };
 
 enum ServerOpcode : unsigned char
@@ -34,4 +35,5 @@ enum ServerOpcode : unsigned char
     kNotifyPartyInfo,
     kNotifyPartyInvite,
     kNotifyCharacterTravel,
+    kNotifyActorValueChanges
 };

--- a/Code/encoding/src/Messages/ClientMessageFactory.cpp
+++ b/Code/encoding/src/Messages/ClientMessageFactory.cpp
@@ -16,6 +16,7 @@
 #include <Messages/PartyAcceptInviteRequest.h>
 #include <Messages/PartyLeaveRequest.h>
 #include <Messages/CharacterTravelRequest.h>
+#include <Messages/RequestActorValueChanges.h>
 
 #include <iostream>
 
@@ -48,6 +49,7 @@ UniquePtr<ClientMessage> ClientMessageFactory::Extract(TiltedPhoques::Buffer::Re
         EXTRACT_MESSAGE(PartyAcceptInviteRequest);
         EXTRACT_MESSAGE(PartyLeaveRequest);
         EXTRACT_MESSAGE(CharacterTravelRequest);
+        EXTRACT_MESSAGE(RequestActorValueChanges);
     }
 
     return UniquePtr<ClientMessage>(nullptr, &TiltedPhoques::Delete<ClientMessage>);

--- a/Code/encoding/src/Messages/NotifyActorValueChanges.cpp
+++ b/Code/encoding/src/Messages/NotifyActorValueChanges.cpp
@@ -1,0 +1,22 @@
+#include <Messages/NotifyActorValueChanges.h>
+#include <Serialization.hpp>
+
+void NotifyActorValueChanges::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept
+{
+    Serialization::WriteVarInt(aWriter, m_formId);
+    Serialization::WriteVarInt(aWriter, m_health);
+}
+
+void NotifyActorValueChanges::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
+{
+    ServerMessage::DeserializeRaw(aReader);
+
+    auto formId = Serialization::ReadVarInt(aReader);
+    auto health = Serialization::ReadVarInt(aReader);
+
+    m_formId = formId;
+    m_health = health;
+
+    //std::cout << "Form ID: " << formId << " Health: " << formId << std::endl;
+    //std::cout << "Form ID 2: " << m_formId << " Health 2: " << m_health << std::endl;
+}

--- a/Code/encoding/src/Messages/NotifyActorValueChanges.cpp
+++ b/Code/encoding/src/Messages/NotifyActorValueChanges.cpp
@@ -3,20 +3,27 @@
 
 void NotifyActorValueChanges::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept
 {
-    Serialization::WriteVarInt(aWriter, m_formId);
-    Serialization::WriteVarInt(aWriter, m_health);
+    Serialization::WriteVarInt(aWriter, m_Id);
+
+    Serialization::WriteVarInt(aWriter, m_values.size());
+    for (auto& value : m_values)
+    {
+        Serialization::WriteVarInt(aWriter, value.first);
+        Serialization::WriteFloat(aWriter, value.second);
+    }
 }
 
 void NotifyActorValueChanges::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
 {
     ServerMessage::DeserializeRaw(aReader);
 
-    auto formId = Serialization::ReadVarInt(aReader);
-    auto health = Serialization::ReadVarInt(aReader);
+    m_Id = Serialization::ReadVarInt(aReader);
 
-    m_formId = formId;
-    m_health = health;
-
-    //std::cout << "Form ID: " << formId << " Health: " << formId << std::endl;
-    //std::cout << "Form ID 2: " << m_formId << " Health 2: " << m_health << std::endl;
+    auto count = Serialization::ReadVarInt(aReader);
+    for (int i = 0; i < count; i += 2)
+    {
+        auto key = Serialization::ReadVarInt(aReader);
+        auto value = Serialization::ReadFloat(aReader);
+        m_values.insert({key, value});
+    }
 }

--- a/Code/encoding/src/Messages/RequestActorValueChanges.cpp
+++ b/Code/encoding/src/Messages/RequestActorValueChanges.cpp
@@ -1,0 +1,20 @@
+#include <Messages/RequestActorValueChanges.h>
+#include <Serialization.hpp>
+#include <iostream>
+
+void RequestActorValueChanges::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept
+{
+    Serialization::WriteVarInt(aWriter, m_formId);
+    Serialization::WriteVarInt(aWriter, m_health);
+}
+
+void RequestActorValueChanges::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
+{
+    ClientMessage::DeserializeRaw(aReader);
+
+    auto formId = Serialization::ReadVarInt(aReader);
+    auto health = Serialization::ReadVarInt(aReader);
+    //Cookie = Serialization::ReadVarInt(aReader) & 0xFFFFFFFF;
+    m_formId = formId;
+    m_health = health;
+}

--- a/Code/encoding/src/Messages/RequestActorValueChanges.cpp
+++ b/Code/encoding/src/Messages/RequestActorValueChanges.cpp
@@ -1,20 +1,29 @@
 #include <Messages/RequestActorValueChanges.h>
 #include <Serialization.hpp>
-#include <iostream>
 
 void RequestActorValueChanges::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept
 {
-    Serialization::WriteVarInt(aWriter, m_formId);
-    Serialization::WriteVarInt(aWriter, m_health);
+    Serialization::WriteVarInt(aWriter, m_Id);
+
+    Serialization::WriteVarInt(aWriter, m_values.size());
+    for (auto& value : m_values)
+    {
+        Serialization::WriteVarInt(aWriter, value.first);
+        Serialization::WriteFloat(aWriter, value.second);
+    }
 }
 
 void RequestActorValueChanges::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
 {
     ClientMessage::DeserializeRaw(aReader);
 
-    auto formId = Serialization::ReadVarInt(aReader);
-    auto health = Serialization::ReadVarInt(aReader);
-    //Cookie = Serialization::ReadVarInt(aReader) & 0xFFFFFFFF;
-    m_formId = formId;
-    m_health = health;
+    m_Id = Serialization::ReadVarInt(aReader);
+
+    auto count = Serialization::ReadVarInt(aReader);
+    for (int i = 0; i < count; i += 2)
+    {
+        auto key = Serialization::ReadVarInt(aReader);
+        auto value = Serialization::ReadFloat(aReader);
+        m_values.insert({key, value});
+    }
 }

--- a/Code/encoding/src/Messages/ServerMessageFactory.cpp
+++ b/Code/encoding/src/Messages/ServerMessageFactory.cpp
@@ -16,6 +16,7 @@
 #include <Messages/NotifyPartyInfo.h>
 #include <Messages/NotifyPartyInvite.h>
 #include <Messages/NotifyCharacterTravel.h>
+#include <Messages/NotifyActorValueChanges.h>
 
 #define EXTRACT_MESSAGE(Name) case k##Name: \
     { \
@@ -46,6 +47,7 @@ UniquePtr<ServerMessage> ServerMessageFactory::Extract(TiltedPhoques::Buffer::Re
         EXTRACT_MESSAGE(NotifyPartyInfo);
         EXTRACT_MESSAGE(NotifyPartyInvite);
         EXTRACT_MESSAGE(NotifyCharacterTravel);
+        EXTRACT_MESSAGE(NotifyActorValueChanges);
     }
 
     return UniquePtr<ServerMessage>(nullptr, &TiltedPhoques::Delete<ServerMessage>);

--- a/Code/server/include/Services/ActorService.h
+++ b/Code/server/include/Services/ActorService.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Events/PacketEvent.h>
+
+struct World;
+struct UpdateEvent;
+struct TransportService;
+struct RequestActorValueChanges;
+
+struct ActorService
+{
+    ActorService(entt::dispatcher& aDispatcher, World& aWorld) noexcept;
+    ~ActorService() noexcept;
+
+    TP_NOCOPYMOVE(ActorService);
+
+  private:
+    World& m_world;
+
+    void OnActorValueChanges(const PacketEvent<RequestActorValueChanges>& acMessage) const noexcept;
+
+    entt::scoped_connection m_updateHealthConnection;
+};

--- a/Code/server/src/GameServer.cpp
+++ b/Code/server/src/GameServer.cpp
@@ -22,6 +22,7 @@
 #include <Messages/PartyAcceptInviteRequest.h> 
 #include <Messages/PartyLeaveRequest.h> 
 #include <Messages/CharacterTravelRequest.h> 
+#include <Messages/RequestActorValueChanges.h>
 
 #include <Scripts/Player.h>
 
@@ -120,6 +121,7 @@ void GameServer::OnConsume(const void* apData, const uint32_t aSize, const Conne
         SERVER_DISPATCH(PartyAcceptInviteRequest);
         SERVER_DISPATCH(PartyLeaveRequest);
         SERVER_DISPATCH(CharacterTravelRequest);
+        SERVER_DISPATCH(RequestActorValueChanges);
     default:
         spdlog::error("Client message opcode {} from {:x} has no handler", pMessage->GetOpcode(), aConnectionId);
         break;

--- a/Code/server/src/Services/ActorService.cpp
+++ b/Code/server/src/Services/ActorService.cpp
@@ -19,13 +19,14 @@ ActorService::~ActorService() noexcept
 void ActorService::OnActorValueChanges(const PacketEvent<RequestActorValueChanges>& acMessage) const noexcept
 {
     NotifyActorValueChanges notifyChanges;
-    notifyChanges.m_formId = acMessage.Packet.m_formId;
-    notifyChanges.m_health = acMessage.Packet.m_health;
+    notifyChanges.m_Id = acMessage.Packet.m_Id;
+    notifyChanges.m_values = acMessage.Packet.m_values;
 
     auto view = m_world.view<PlayerComponent>();
     for (auto entity : view)
     {
         auto& player = view.get<PlayerComponent>(entity);
+
         if (player.ConnectionId != acMessage.ConnectionId)
         {
             GameServer::Get()->Send(player.ConnectionId, notifyChanges);

--- a/Code/server/src/Services/ActorServices.cpp
+++ b/Code/server/src/Services/ActorServices.cpp
@@ -1,0 +1,34 @@
+#include <Components.h>
+#include <Events/UpdateEvent.h>
+#include <Messages/RequestActorValueChanges.h>
+#include <Services/ActorService.h>
+#include <World.h>
+#include <GameServer.h>
+#include <Messages/NotifyActorValueChanges.h>
+
+ActorService::ActorService(entt::dispatcher& aDispatcher, World& aWorld) noexcept
+    : m_world(aWorld)
+{
+    m_updateHealthConnection = aDispatcher.sink<PacketEvent<RequestActorValueChanges>>().connect<&ActorService::OnActorValueChanges>(this);
+}
+
+ActorService::~ActorService() noexcept
+{
+}
+
+void ActorService::OnActorValueChanges(const PacketEvent<RequestActorValueChanges>& acMessage) const noexcept
+{
+    NotifyActorValueChanges notifyChanges;
+    notifyChanges.m_formId = acMessage.Packet.m_formId;
+    notifyChanges.m_health = acMessage.Packet.m_health;
+
+    auto view = m_world.view<PlayerComponent>();
+    for (auto entity : view)
+    {
+        auto& player = view.get<PlayerComponent>(entity);
+        if (player.ConnectionId != acMessage.ConnectionId)
+        {
+            GameServer::Get()->Send(player.ConnectionId, notifyChanges);
+        }
+    }
+}

--- a/Code/server/src/World.cpp
+++ b/Code/server/src/World.cpp
@@ -7,6 +7,7 @@
 #include <Services/QuestService.h>
 #include <Services/ServerListService.h>
 #include <Services/PartyService.h>
+#include <Services/ActorService.h>
 
 World::World()
 {
@@ -17,6 +18,7 @@ World::World()
     set<ServerListService>(*this, m_dispatcher);
     set<QuestService>(*this, m_dispatcher);
     set<PartyService>(*this, m_dispatcher);
+    set<ActorService>(m_dispatcher, *this);
 
     // late initialize the ScriptService to ensure all components are valid
     m_scriptService = std::make_unique<ScriptService>(*this, m_dispatcher);


### PR DESCRIPTION
Periodically syncs actor values for actors owned by the client. Actor values are cached as to not send redundant information. Hooking into the damage event not implemented yet.
Issue #38 