### PR TITLE
Added Player.position parameter to lua script API.

### DIFF
--- a/Code/server/include/Scripts/Player.h
+++ b/Code/server/include/Scripts/Player.h
@@ -18,6 +18,9 @@ namespace Script
         const String& GetName() const;
         const uint64_t GetDiscordId() const;
 
+        // Lua doesn't like Vector3s, so I made it be an array instead. Index starts at 1, rather than 0. Player.position[1] is x, Player.position[2] is y, Player.position[3] is z. Not sure why that is though - bable631
+        [[nodiscard]] const std::initializer_list<float> GetPositionL() const;
+
         [[nodiscard]] const Vector3<float>& GetPosition() const;
         [[nodiscard]] const Vector3<float>& GetRotation() const;
         [[nodiscard]] float GetSpeed() const;

--- a/Code/server/src/Scripts/Player.cpp
+++ b/Code/server/src/Scripts/Player.cpp
@@ -43,6 +43,14 @@ namespace Script
         auto& movementComponent = m_pWorld->get<MovementComponent>(m_entity);
         return movementComponent.Position;
     }
+    //Lua doesn't like Vector3s, so I made it be an array instead. Index starts at 1, rather than 0. Player.position[1] is x, Player.position[2] is y, Player.position[3] is z. Not sure why that is though - bable631
+    const std::initializer_list<float> Player::GetPositionL() const
+    {
+        auto& movementComponent = m_pWorld->get<MovementComponent>(m_entity);
+        std::initializer_list<float> arr = {movementComponent.Position.m_x, movementComponent.Position.m_y,
+                                            movementComponent.Position.m_z};
+        return arr;
+    }
 
     const Vector3<float>& Player::GetRotation() const
     {

--- a/Code/server/src/Services/ScriptService.cpp
+++ b/Code/server/src/Services/ScriptService.cpp
@@ -216,10 +216,13 @@ void ScriptService::BindTypes(ScriptContext& aContext) noexcept
     playerType["ip"] = sol::readonly_property(&Player::GetIp);
     playerType["party"] = sol::readonly_property(&Player::GetParty);
     playerType["discordid"] = sol::readonly_property(&Player::GetDiscordId);
+    // Lua doesn't like Vector3s, so I made it be an array instead. Index starts at 1, rather than 0. Player.position[1] is x, Player.position[2] is y, Player.position[3] is z. Not sure why that is though - bable631
+    playerType["position"] = sol::readonly_property(&Player::GetPositionL);
     playerType["AddComponent"] = &Player::AddComponent;
     playerType["AddQuest"] = &Player::AddQuest;
     playerType["GetQuests"] = &Player::GetQuests;
     playerType["RemoveQuest"] = &Player::RemoveQuest; 
+
 
     auto questType = aContext.new_usertype<Quest>("Quest", sol::no_constructor);
     questType["id"] = sol::readonly_property(&Quest::GetId);


### PR DESCRIPTION
Player.position is a table in lua, rather than a vector3, because lua doesn't like vector3s. Player.position[1] is x, Player.position[2] is y, Player.position[3] is z. This gets the player's current position in the cell or worldspace that the player is in. It is currently not possible to get a player's current cell or similar, so you'll have to bear that in mind when using this. It seems like it can also not be called in onPlayerJoin because it will just crash. onPlayerEnterWorld works just fine though.