### PR TITLE
Fix crash by pickpocket fix

### DIFF
--- a/Code/client/src/Services/Generic/CharacterService.cpp
+++ b/Code/client/src/Services/Generic/CharacterService.cpp
@@ -934,6 +934,9 @@ void CharacterService::RunSpawnUpdates() const noexcept
 
 void CharacterService::ApplyCachedInventoryChanges() noexcept
 {
+    if (!World::Get().ctx<PapyrusService>().Get("UI", "IsMenuOpen"))
+        return;
+
     GLOBAL_PAPYRUS_FUNCTION(bool, UI, IsMenuOpen, BSFixedString)
 
     if (s_pIsMenuOpen(BSFixedString("ContainerMenu")))

--- a/Code/client/src/Services/Generic/CharacterService.cpp
+++ b/Code/client/src/Services/Generic/CharacterService.cpp
@@ -934,8 +934,14 @@ void CharacterService::RunSpawnUpdates() const noexcept
 
 void CharacterService::ApplyCachedInventoryChanges() noexcept
 {
-    if (!World::Get().ctx<PapyrusService>().Get("UI", "IsMenuOpen"))
+
+    static bool papyrusFunctionsInitialized = false;
+
+    if (!papyrusFunctionsInitialized && !World::Get().ctx<PapyrusService>().Get("UI", "IsMenuOpen"))
         return;
+    else
+        papyrusFunctionsInitialized = true;
+         
 
     GLOBAL_PAPYRUS_FUNCTION(bool, UI, IsMenuOpen, BSFixedString)
 


### PR DESCRIPTION
aims to fix undeterministic crash on load that was introduced in #82 
- functionality of #82 is tested and still working
- could not reproduce the crash after or before this fix; someone who could reproduce the crash, please test