### PR TITLE
Github Actions for Linux aarch64

### DIFF
--- a/.github/workflows/linux-aarch64.yml
+++ b/.github/workflows/linux-aarch64.yml
@@ -1,0 +1,53 @@
+name: Build linux (aarch64)
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu20.04]
+        arch: [aarch64]
+        arch_alias: [arm64-v8a]
+        mode: [debug, release]
+      fail-fast: true
+
+    runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: uraimo/run-on-arch-action@v2.1.1
+      name: Virtualize & Build
+      with:
+        arch: ${{ matrix.arch }}
+        distro: ${{ matrix.os }}
+        run: |
+          echo "Installing dependencies"
+          apt-get update && apt-get upgrade -y
+          DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential gcc g++ bash curl unzip m4 pkg-config cmake autoconf automake
+
+          echo "Updating submodules"
+          git submodule sync --recursive
+          git submodule update --init --force --recursive --depth=1
+
+          echo "Fixing permissions"
+          chown -R $UID:$UID .
+
+          echo "Installing xmake"
+          bash <(curl -fsSL https://xmake.io/shget.text)
+          source ~/.xmake/profile
+
+          echo "Tuning config for ${{ matrix.arch }}"
+          sed -i s/x64/${{ matrix.arch }}/g xmake.lua
+          xmake config --root --arch=${{ matrix.arch_alias }} --mode=${{ matrix.mode }} --yes
+          xmake --root
+          xmake install --root -o packaged
+
+    # Upload artifacts
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.mode }}
+        path: packaged/bin/**


### PR DESCRIPTION
This PR adds support for `aarch64` linux builds on Github Actions, which allows the artifacts to run on hardware like Raspberry Pi, or on cloud instances with lower performance per dollar, like AWS Graviton, or Oracle Cloud's Ampere A1 Compute.

At the time of edit:
- Completed action on another branch (`master` on my fork): https://github.com/jameshi16/TiltedOnline/actions/runs/1568145772
    [![Build linux (aarch64)](https://github.com/jameshi16/TiltedOnline/actions/workflows/linux-aarch64.yml/badge.svg?branch=master)](https://github.com/jameshi16/TiltedOnline/actions/workflows/linux-aarch64.yml)
- Completed action on incoming branch (`feature-aarch64-build` on my fork): https://github.com/jameshi16/TiltedOnline/actions/runs/1568982354
    [![Build linux (aarch64)](https://github.com/jameshi16/TiltedOnline/actions/workflows/linux-aarch64.yml/badge.svg?branch=feature-aarch64-build)](https://github.com/jameshi16/TiltedOnline/actions/workflows/linux-aarch64.yml)